### PR TITLE
fixed file permissions

### DIFF
--- a/wp-smush.php
+++ b/wp-smush.php
@@ -223,6 +223,15 @@ if ( ! class_exists( 'WpSmush' ) ) {
 				unlink( $tempfile );
 			}
 
+			$fixedFilePermissions = chmod($file_path, 0644);
+
+			if ($fixedFilePermissions) {
+				// great!
+			}
+			else {
+				// damn!
+			}
+
 			return $response;
 		}
 


### PR DESCRIPTION
On one of the sites I manage, WP-SmushIt works great at the smushing, but the file permissions get screwed up, going from 0644 -> 0600 and making the images unavailable (403 forbidden error).

This is possibly down to an incompatibility with another plugin, such as Wordfence security. I can confirm that the problem is not down to suPHP ([as was the problem in this post](https://wordpress.org/support/topic/plugin-wp-smushit-can-not-find-the-image)), as suPHP is in fact enabled on the web host.

This commit fixes that by automatically chmoding the file in question, back to the standard 0644.
